### PR TITLE
Optimize global_atomic_counter on host side with MemsetAysnc

### DIFF
--- a/csrc/deep_ep.hpp
+++ b/csrc/deep_ep.hpp
@@ -65,6 +65,10 @@ private:
     // Workspace
     void* workspace = nullptr;
 
+    // global_atomic_counter
+    int* dispatch_global_atomic_counter = nullptr;
+    int* combine_global_atomic_counter = nullptr;
+
     // Host-side MoE info
     volatile int* moe_recv_counter = nullptr;
     int* moe_recv_counter_mapped = nullptr;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
`auto global_atomic_counter = torch::zeros({1}, torch::dtype(torch::kInt32).device(torch::kCUDA)); `
will introduce 5us overhead for each counter initialization on host side.
It will hurt E2E performance since per layer if we call 1 dispatch + 1 combine, there will be 10us overhead for counter initialization.


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
We are introducing two member variables to the Buffer struct, namely `dispatch_global_atomic_counter` and `combine_global_atomic_counter`. We intend to allocate these counters once during the initialization of the buffer and then reset their values to zero each time before use with MemsetAsync, which should incur an overhead of approximately 1.5us.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
For code stability, it should at least pass a 48-hour stress test.

## Test Result

<!-- Briefly summarize test outcomes. -->
This code change has passed a 48-hour stress test.

## Submission Checklist

- ✅ Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
