### PR TITLE
[Build] Link PYTORCH_ROCM_ARCH specified archs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -202,6 +202,8 @@ if __name__ == "__main__":
                 "-libverbs",
             ]
         )
+        arch_env = os.environ["PYTORCH_ROCM_ARCH"]
+        extra_link_args.extend([f"--offload-arch={arch}" for arch in arch_env.split(";")])
         if enable_mpi:
             extra_link_args.extend(
                 [


### PR DESCRIPTION
## Motivation

In the [vLLM CI](https://buildkite.com/vllm/amd-ci/builds/6809/steps/canvas?sid=019d19a7-6ade-497f-ba2f-6a838dfeac43&tab=output#019d19a7-6bca-4e0b-ac96-64f1239a2cff/L2909) we see the error message

> 'Failed: CUDA error /app/DeepEP/csrc/kernels/launch_hip.cuh:71 'invalid kernel file''

when using `deep_ep`. Although we specify `gfx950` in the env var `PYTORCH_ROCM_ARCH`, the `gfx950` kernels are not linked into the shared object.

## Technical Details

The offload architectures are explicitly linked into the shared object file. Previously, whatever architecture was discovered at runtime was linked.